### PR TITLE
fix: add security validations for document upload

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,4 +11,9 @@ SECRET_KEY=your-secret-key-change-this-in-production
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
+# File Upload Configuration
+UPLOAD_DIR=uploads/documents
+MAX_FILE_SIZE=10485760
+ALLOWED_EXTENSIONS=.pdf,.doc,.docx,.txt,.png,.jpg,.jpeg
+
 #Anything added here needs to be sync with config

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -23,6 +23,13 @@ class Settings(BaseSettings):
 
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
 
+    # File Upload Configuration
+    UPLOAD_DIR: str = "uploads/documents"
+
+    MAX_FILE_SIZE: int = 10485760  # 10MB in bytes
+
+    ALLOWED_EXTENSIONS: str = ".pdf,.doc,.docx,.txt,.png,.jpg,.jpeg"
+
     def __init__(self, **values):
         super().__init__(**values)
         if not self.DEBUG:

--- a/backend/routers/document.py
+++ b/backend/routers/document.py
@@ -1,16 +1,16 @@
 import os
 import uuid
 
-from fastapi import APIRouter, Depends, File, UploadFile, HTTPException
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from core.config import settings
 from core.dependencies import get_current_user
 from db.database import get_db
-from models.user import User
 from models.document import Document
 from models.status import Status
+from models.user import User
 
 router = APIRouter(prefix="/documents", tags=["documents"])
 

--- a/backend/routers/document.py
+++ b/backend/routers/document.py
@@ -1,15 +1,16 @@
 import os
 import uuid
 
-from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi import APIRouter, Depends, File, UploadFile, HTTPException
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
+from core.config import settings
+from core.dependencies import get_current_user
 from db.database import get_db
+from models.user import User
 from models.document import Document
 from models.status import Status
-
-UPLOAD_DIR = "uploads/documents"
 
 router = APIRouter(prefix="/documents", tags=["documents"])
 
@@ -18,35 +19,68 @@ router = APIRouter(prefix="/documents", tags=["documents"])
 async def upload_document(
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
 
-    # Ensure upload directory exists
-    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    allowed_extensions = set(
+        ext.strip() for ext in settings.ALLOWED_EXTENSIONS.split(",")
+    )
+    file_ext = os.path.splitext(file.filename)[1].lower()
 
-    ext = os.path.splitext(file.filename)[1]
-    stored_filename = f"{uuid.uuid4()}{ext}"
-    file_path = os.path.join(UPLOAD_DIR, stored_filename)
+    if file_ext not in allowed_extensions:
+        raise HTTPException(
+            status_code=400,
+            detail=f"File type '{file_ext}' not allowed. Allowed types: {settings.ALLOWED_EXTENSIONS}",
+        )
+
+    contents = await file.read()
+    file_size = len(contents)
+
+    if file_size > settings.MAX_FILE_SIZE:
+        max_size_mb = settings.MAX_FILE_SIZE / 1024 / 1024
+        raise HTTPException(
+            status_code=400,
+            detail=f"File size ({file_size / 1024 / 1024:.2f}MB) exceeds maximum allowed size ({max_size_mb}MB)",
+        )
+
+    os.makedirs(settings.UPLOAD_DIR, exist_ok=True)
+
+    stored_filename = f"{uuid.uuid4()}{file_ext}"
+    file_path = os.path.join(settings.UPLOAD_DIR, stored_filename)
 
     # Save file to disk
-    with open(file_path, "wb") as buffer:
-        while chunk := await file.read(1024 * 1024):
-            buffer.write(chunk)
+    try:
+        with open(file_path, "wb") as buffer:
+            buffer.write(contents)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to save file: {str(e)}")
 
     uploaded_status = db.query(Status).filter(Status.name == "Uploaded").first()
 
+    if not uploaded_status:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+        raise HTTPException(
+            status_code=500, detail="Uploaded status not found in database"
+        )
     # Create document record in database
     document = Document(
-        user_id=1,  # In a real app, get the user ID from the authenticated user
+        user_id=current_user.id,
         original_filename=file.filename,
         stored_filename=stored_filename,
         file_path=file_path,
         content_type=file.content_type,
         status_id=uploaded_status.id,
     )
-
-    db.add(document)
-    db.commit()
-    db.refresh(document)
+    try:
+        db.add(document)
+        db.commit()
+        db.refresh(document)
+    except Exception as e:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Database error: {str(e)}")
 
     return JSONResponse(
         content={


### PR DESCRIPTION
- Add user authentication requirement using get_current_user
- Implement file type validation with whitelist
- Add file size limit (10MB maximum)
- Move hardcoded configuration to settings
- Replace TODO user_id with authenticated user